### PR TITLE
Add mark placeholder to email subject text

### DIFF
--- a/SARate/SARateViewController.m
+++ b/SARate/SARateViewController.m
@@ -232,8 +232,8 @@
         
         NSArray *toRecipients = [NSArray arrayWithObjects:_email, nil];
         [mailer setToRecipients:toRecipients];
-        [mailer setSubject:_emailSubject];
-        NSString *emailBody = _emailText;
+        [mailer setSubject:[_emailSubject stringByReplacingOccurrencesOfString:@"{mark}" withString:[[NSNumber numberWithInt: _mark] stringValue]]];
+        NSString *emailBody = [_emailText stringByReplacingOccurrencesOfString:@"{mark}" withString:[[NSNumber numberWithInt: _mark] stringValue]];
         [mailer setMessageBody:emailBody isHTML:YES];
         mailer.mailComposeDelegate = self;
         


### PR DESCRIPTION
Add mark placeholder to emailSubject and emailText: {mark}

Usage:
SARate.sharedInstance().emailText = "Disadvantages ({mark}*):"

Result:
When user selects a mark and agrees to write an email to developer. SARate will replace {mark} with selected stars number (1, 2, 3, 4, 5). Resulting in emailText = "Disadvantages (2*):"
